### PR TITLE
WIP - Fix downloading books

### DIFF
--- a/kobo-book-downloader/Commands.py
+++ b/kobo-book-downloader/Commands.py
@@ -114,7 +114,7 @@ Examples:
 				raise KoboException( "The parent directory ('%s') of the output file must exist." % parentPath )
 
 		print( "Downloading book to '%s'." % outputPath )
-		Globals.Kobo.Download( revisionId, Kobo.DisplayProfile, outputPath )
+		Globals.Kobo.Download( revisionId, None, Kobo.DisplayProfile, outputPath )
 
 	@staticmethod
 	def __GetAllBooks( outputPath: str ) -> None:
@@ -129,7 +129,7 @@ Examples:
 				continue
 
 			# Only process e-books, no audio-books etc.
-			bookMetadata = newEntitlement[ "BookMetadata" ]
+			bookMetadata = newEntitlement.get ( "BookMetadata" )
 			if bookMetadata is None:
 				continue
 
@@ -148,7 +148,7 @@ Examples:
 
 			print( "Downloading book to '%s'." % outputFilePath )
 
-			Globals.Kobo.Download(bookMetadata["RevisionId"], Kobo.DisplayProfile, outputFilePath)
+			Globals.Kobo.Download(bookMetadata["RevisionId"], bookMetadata["DownloadUrls"], Kobo.DisplayProfile, outputFilePath)
 
 	@staticmethod
 	def GetBookOrBooks( revisionId: str, outputPath: str, getAll: bool ) -> None:

--- a/kobo-book-downloader/Commands.py
+++ b/kobo-book-downloader/Commands.py
@@ -128,7 +128,11 @@ Examples:
 			if newEntitlement is None:
 				continue
 
+			# Only process e-books, no audio-books etc.
 			bookMetadata = newEntitlement[ "BookMetadata" ]
+			if bookMetadata is None:
+				continue
+
 			fileName = Commands.__MakeFileNameForBook( bookMetadata )
 			outputFilePath = os.path.join( outputPath, fileName )
 
@@ -143,7 +147,8 @@ Examples:
 				continue
 
 			print( "Downloading book to '%s'." % outputFilePath )
-			Globals.Kobo.Download( bookMetadata[ "RevisionId" ], Kobo.DisplayProfile, outputFilePath )
+
+			Globals.Kobo.Download(bookMetadata["RevisionId"], Kobo.DisplayProfile, outputFilePath)
 
 	@staticmethod
 	def GetBookOrBooks( revisionId: str, outputPath: str, getAll: bool ) -> None:
@@ -193,15 +198,16 @@ Examples:
 				if bookEntitlement.get( "IsLocked" ):
 					continue
 
-			if ( not listAll ) and Commands.__IsBookRead( newEntitlement ):
-				continue
+				bookMetadata = newEntitlement["BookMetadata"]
+				book = [bookMetadata["RevisionId"],
+						bookMetadata["Title"],
+						Commands.__GetBookAuthor(bookMetadata),
+						Commands.__IsBookArchived(newEntitlement)]
 
-			bookMetadata = newEntitlement[ "BookMetadata" ]
-			book = [ bookMetadata[ "RevisionId" ],
-				bookMetadata[ "Title" ],
-				Commands.__GetBookAuthor( bookMetadata ),
-				Commands.__IsBookArchived( newEntitlement ) ]
-			rows.append( book )
+				if ( not listAll ) and Commands.__IsBookRead( newEntitlement ):
+					continue
+
+				rows.append( book )
 
 		rows = sorted( rows, key = lambda columns: columns[ 1 ].lower() )
 		return rows


### PR DESCRIPTION
I've fixed the GetAllBooks downloads, but I cannot get the DRM decryption to work agian.

In the process I found another DRM type called **SocialDrm**. In this case the e-book can be used on all my devices, but its '**watermarked**'. For me this is not a issue (and even preferred), I don't want to use the tool for piracy but only to have the e-books in a DRM-free format.

This SocialDrm download url is not supplied when the client identifies its-self as Android client.
Only in the book listing call. Due inconsistencies in the Kobo API response types its hard (for me in Python) to create a generic method that handles both scenario's.

Maybe someone can help me out here?
In my view, when available, a book 'protected' by SocialDrm should have the first choice. If not available other DRM types could be downloaded and decrypted. Im not able to get this last part done.  

