### PR TITLE
Fix Windows compatibility issues

### DIFF
--- a/kobo-book-downloader/Commands.py
+++ b/kobo-book-downloader/Commands.py
@@ -129,7 +129,10 @@ Examples:
 			if newEntitlement is None:
 				continue
 
-			bookMetadata = newEntitlement[ "BookMetadata" ]
+			bookMetadata = newEntitlement.get( "BookMetadata" )
+			if bookMetadata is None:
+				continue
+
 			fileName = Commands.__MakeFileNameForBook( bookMetadata )
 			outputFilePath = os.path.join( outputPath, fileName )
 

--- a/kobo-book-downloader/Kobo.py
+++ b/kobo-book-downloader/Kobo.py
@@ -20,7 +20,6 @@ import urllib
 try:
 	import readline
 except ImportError:
-	# readline is not available on Windows, but it's only needed for MacOS input issues
 	pass
 
 class KoboException( Exception ):

--- a/kobo-book-downloader/Kobo.py
+++ b/kobo-book-downloader/Kobo.py
@@ -16,7 +16,12 @@ import urllib
 # It was not possible to enter the entire captcha response on MacOS.
 # Importing readline changes the implementation of input() and solves the issue.
 # See https://stackoverflow.com/q/65735885 and https://stackoverflow.com/q/7357007.
-import readline
+# readline is not available on Windows, so we import it conditionally.
+try:
+	import readline
+except ImportError:
+	# readline is not available on Windows, but it's only needed for MacOS input issues
+	pass
 
 class KoboException( Exception ):
 	pass


### PR DESCRIPTION
This PR addresses two critical issues that prevented the tool from working on Windows:

## Changes

### 1. Fix ModuleNotFoundError for readline module on Windows
- Added try/except block to conditionally import readline
- `readline` is only available on Unix/Linux/MacOS, not on Windows
- The module is only needed to fix MacOS input issues, so it's safe to skip on Windows

### 2. Fix KeyError when BookMetadata is missing
- Changed direct dictionary access to use `.get()` method with None check
- Some items in the book list may not have `BookMetadata` field
- This prevents crashes when downloading all books with `--all` flag

## Testing
Tested on Windows 11 with Python 3.x. The tool now:
- ✅ Runs without ModuleNotFoundError
- ✅ Successfully handles book entries without BookMetadata
- ✅ Downloads books without crashes

Both fixes ensure the tool works correctly on Windows systems while maintaining compatibility with other platforms.